### PR TITLE
Fixed multiple quotes on a line issue

### DIFF
--- a/grammars/gherkin.cson
+++ b/grammars/gherkin.cson
@@ -24,11 +24,11 @@
         "name": 'constant.character.escape.feature'
     }
     {
-        "match": "(\\'.*\\')"
+        "match": "(\\'.*?[^\\']\\')"
         "name": 'string.single.qoute.gherkin'
     }
     {
-        "match": '(\\".*\\")'
+        "match": '(\\".*?[^\\"]\\")'
         "name": 'string.double.qoute.gherkin'
     }
     {


### PR DESCRIPTION
update regex to NOT hightlight text between two sets of quotes (single and or double) on a single line
